### PR TITLE
CIE-6997: Migrate from Bitnami

### DIFF
--- a/spark.Dockerfile
+++ b/spark.Dockerfile
@@ -11,9 +11,6 @@ WORKDIR /sam_fhir
 RUN df -h # for space monitoring
 RUN pipenv sync --system --dev --extra-pip-args="--prefer-binary"
 
-# COPY ./jars/* /opt/bitnami/spark/jars/
-# COPY ./conf/* /opt/bitnami/spark/conf/
-
 # override entrypoint to remove extra logging
 RUN mv /opt/minimal_entrypoint.sh /opt/entrypoint.sh
 

--- a/spark_auto_mapper_fhir/Makefile.docker
+++ b/spark_auto_mapper_fhir/Makefile.docker
@@ -21,8 +21,8 @@ helm:
 
 .PHONY:helmchart
 helmchart:
-	helm repo add apache-spark https://github.com/apache/spark/tree/master/resource-managers/kubernetes/docker/src/main/dockerfiles/spark
-	helm install my-release apache-spark/spark
+	helm repo add bitnami https://charts.bitnami.com/bitnami
+	helm install my-release bitnami/spark
 
 .PHONY:up
 up:

--- a/spark_auto_mapper_fhir/Makefile.docker
+++ b/spark_auto_mapper_fhir/Makefile.docker
@@ -21,8 +21,8 @@ helm:
 
 .PHONY:helmchart
 helmchart:
-	helm repo add bitnami https://charts.bitnami.com/bitnami
-	helm install my-release bitnami/spark
+	helm repo add apache-spark https://github.com/apache/spark/tree/master/resource-managers/kubernetes/docker/src/main/dockerfiles/spark
+	helm install my-release apache-spark/spark
 
 .PHONY:up
 up:

--- a/spark_auto_mapper_fhir/docker-compose.yml
+++ b/spark_auto_mapper_fhir/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   spark:
-    image: docker.io/bitnami/spark:3.1.1-debian-10-r46
+    image: spark:3.1.1
     environment:
       - SPARK_MODE=master
       - SPARK_RPC_AUTHENTICATION_ENABLED=no
@@ -16,7 +16,7 @@ services:
     - ${HOME}:${HOME}
     restart: always
   spark-worker-1:
-    image: docker.io/bitnami/spark:3.1.1-debian-10-r46
+    image: spark:3.1.1
     environment:
       - SPARK_MODE=worker
       - SPARK_MASTER_URL=spark://spark:7077


### PR DESCRIPTION
# CIE-6997: Migrate from Bitnami Images and Helm Charts

## Summary
This PR migrates away from Bitnami images and Helm charts due to their deprecation of the public catalog on Sep. 29th, 2025. Only the minimum necessary changes have been made to replace Bitnami dependencies with official alternatives.

## Key Changes
- **Docker Images**: Replaced Bitnami images with official alternatives (kafka, redis, mongodb, etc.)
- **Helm Charts**: Updated chart dependencies from charts.bitnami.com to official repositories
- **Volume Paths**: Updated mount paths to match new image structures
- **Default Credentials**: Updated from "bitnami" defaults to standard defaults where applicable

## Action Required
**Please review all Docker and Helm configuration changes carefully** - while only minimum changes were made, teams should verify:
- Local development environments still work correctly
- Staging/production deployments function as expected
- Any custom configurations or scripts that depend on Bitnami-specific paths or defaults

## Testing
- [ ] Local docker-compose environments tested
- [ ] Staging deployment verified
- [ ] Production deployment planned

---
*This migration addresses the Bitnami public catalog deprecation. For questions or issues, please reach out to CIE.*
